### PR TITLE
Add env variable NEXTAUTH_SECRET for the production in vercel

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -6,8 +6,6 @@ export const authOptions: AuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || '',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-      // clientId: process.env.GOOGLE_CLIENT_ID || (() => { throw new Error('GOOGLE_CLIENT_ID is not defined') })(),
-      // clientSecret: process.env.GOOGLE_CLIENT_SECRET || (() => { throw new Error('GOOGLE_CLIENT_SECRET is not defined') })(),
     }),
     // Add any other authentication providers like email, GitHub, etc.
   ],
@@ -17,6 +15,7 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt' as SessionStrategy, // Use JWT tokens for session management
   },
+  secret: process.env.NEXTAUTH_SECRET,
 };
  
 export default NextAuth(authOptions);


### PR DESCRIPTION
Set the NEXTAUTH_SECRET in Vercel
Open your Vercel dashboard.

Go to your project > Settings > Environment Variables.

Add a new environment variable:
Name: NEXTAUTH_SECRET
Value: Use a securely generated base64 string:

`openssl rand -base64 32`
Save and redeploy your project.